### PR TITLE
LFP-641

### DIFF
--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -149,11 +149,11 @@ class LunarServiceProvider extends ServiceProvider
             return new OrderModifiers;
         });
 
-        $this->app->singleton(CartSessionInterface::class, function ($app) {
+        $this->app->scoped(CartSessionInterface::class, function ($app) {
             return $app->make(CartSessionManager::class);
         });
 
-        $this->app->singleton(StorefrontSessionInterface::class, function ($app) {
+        $this->app->scoped(StorefrontSessionInterface::class, function ($app) {
             return $app->make(StorefrontSessionManager::class);
         });
 
@@ -161,7 +161,7 @@ class LunarServiceProvider extends ServiceProvider
             return new ShippingModifiers;
         });
 
-        $this->app->singleton(ShippingManifestInterface::class, function ($app) {
+        $this->app->scoped(ShippingManifestInterface::class, function ($app) {
             return $app->make(ShippingManifest::class);
         });
 
@@ -193,7 +193,7 @@ class LunarServiceProvider extends ServiceProvider
             return $app->make(PaymentManager::class);
         });
 
-        $this->app->singleton(DiscountManagerInterface::class, function ($app) {
+        $this->app->scoped(DiscountManagerInterface::class, function ($app) {
             return $app->make(DiscountManager::class);
         });
 


### PR DESCRIPTION
This pull request updates the service bindings in the `LunarServiceProvider` to use the `scoped` lifetime instead of `singleton` for several key services. This means that a new instance of these services will be created per request, rather than sharing a single instance across all requests. This change improves the isolation and correctness of services that may hold request-specific state.

Service lifetime changes:

* Changed the binding of `CartSessionInterface`, `StorefrontSessionInterface`, `ShippingManifestInterface`, and `DiscountManagerInterface` from `singleton` to `scoped` in `LunarServiceProvider.php`, ensuring each request receives a fresh instance. [[1]](diffhunk://#diff-0d481d84704e0c14d0656d3276c361d0c9cb715b4e19df6c5482aca606986f6aL152-R164) [[2]](diffhunk://#diff-0d481d84704e0c14d0656d3276c361d0c9cb715b4e19df6c5482aca606986f6aL196-R196)