### PR TITLE
fix: LFP-739 require minimum cart amount for fixed value discounts

### DIFF
--- a/packages/admin/resources/lang/en/discount.php
+++ b/packages/admin/resources/lang/en/discount.php
@@ -5,6 +5,8 @@ return [
     'label' => 'Discount',
     'notifications' => [
         'fixed_value_requires_coupon' => 'A fixed value discount requires a coupon code. Please set a coupon before saving.',
+        'fixed_value_requires_minimum_cart_amount' => 'A fixed value discount requires a minimum cart amount. Please set a minimum cart amount before saving.',
+        'minimum_cart_amount_below_fixed_value' => 'The minimum cart amount cannot be lower than the fixed value discount amount.',
     ],
     'form' => [
         'conditions' => [

--- a/packages/admin/resources/lang/hu/discount.php
+++ b/packages/admin/resources/lang/hu/discount.php
@@ -5,6 +5,8 @@ return [
     'label' => 'Kedvezmény',
     'notifications' => [
         'fixed_value_requires_coupon' => 'A fix összegű kedvezményhez kuponkód szükséges. Kérjük, mentés előtt adjon meg egy kupont.',
+        'fixed_value_requires_minimum_cart_amount' => 'A fix összegű kedvezményhez meg kell adni a minimum kosárértéket.',
+        'minimum_cart_amount_below_fixed_value' => 'A minimum kosárérték nem lehet kisebb, mint a fix összegű kedvezmény értéke.',
     ],
     'form' => [
         'conditions' => [

--- a/packages/admin/resources/lang/ro/discount.php
+++ b/packages/admin/resources/lang/ro/discount.php
@@ -5,6 +5,8 @@ return [
     'label' => 'Reducere',
     'notifications' => [
         'fixed_value_requires_coupon' => 'O reducere cu valoare fixă necesită un cod de cupon. Vă rugăm să setați un cupon înainte de salvare.',
+        'fixed_value_requires_minimum_cart_amount' => 'O reducere cu valoare fixă necesită o valoare minimă a coșului. Vă rugăm să setați o valoare minimă a coșului înainte de salvare.',
+        'minimum_cart_amount_below_fixed_value' => 'Valoarea minimă a coșului nu poate fi mai mică decât valoarea fixă a reducerii.',
     ],
     'form' => [
         'conditions' => [

--- a/packages/admin/src/Filament/Resources/DiscountResource/Pages/EditDiscount.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/Pages/EditDiscount.php
@@ -86,13 +86,54 @@ class EditDiscount extends BaseEditRecord
 
     protected function mutateFormDataBeforeSave(array $data): array
     {
-        if (($data['data']['fixed_value'] ?? false) && blank($data['coupon'] ?? null)) {
-            Notification::make()
-                ->danger()
-                ->title(__('lunarpanel::discount.notifications.fixed_value_requires_coupon'))
-                ->send();
+        if ($data['data']['fixed_value'] ?? false) {
+            if (blank($data['coupon'] ?? null)) {
+                Notification::make()
+                    ->danger()
+                    ->title(__('lunarpanel::discount.notifications.fixed_value_requires_coupon'))
+                    ->send();
 
-            $this->halt();
+                $this->halt();
+            }
+
+            $missingMinimumCartAmount = false;
+            $minimumCartAmountBelowFixedValue = false;
+
+            foreach ($data['data']['fixed_values'] ?? [] as $currencyCode => $fixedValue) {
+                if (blank($fixedValue)) {
+                    continue;
+                }
+
+                $minPrice = $data['data']['min_prices'][$currencyCode] ?? null;
+
+                if (blank($minPrice)) {
+                    $missingMinimumCartAmount = true;
+
+                    continue;
+                }
+
+                if ((float) $minPrice < (float) $fixedValue) {
+                    $minimumCartAmountBelowFixedValue = true;
+                }
+            }
+
+            if ($missingMinimumCartAmount) {
+                Notification::make()
+                    ->danger()
+                    ->title(__('lunarpanel::discount.notifications.fixed_value_requires_minimum_cart_amount'))
+                    ->send();
+            }
+
+            if ($minimumCartAmountBelowFixedValue) {
+                Notification::make()
+                    ->danger()
+                    ->title(__('lunarpanel::discount.notifications.minimum_cart_amount_below_fixed_value'))
+                    ->send();
+            }
+
+            if ($missingMinimumCartAmount || $minimumCartAmountBelowFixedValue) {
+                $this->halt();
+            }
         }
 
         if (class_exists($data['type'])) {

--- a/tests/admin/Feature/Filament/Resources/DiscountResource/Pages/EditDiscountTest.php
+++ b/tests/admin/Feature/Filament/Resources/DiscountResource/Pages/EditDiscountTest.php
@@ -62,6 +62,7 @@ it('requires a minimum cart amount for fixed value discounts', function () {
         'coupon' => 'FIXED10',
         'data.fixed_value' => true,
         'data.fixed_values.'.$currency->code => 10,
+        'data.min_prices.'.$currency->code => null,
     ])->call('save')
         ->assertNotified(__('lunarpanel::discount.notifications.fixed_value_requires_minimum_cart_amount'));
 
@@ -141,11 +142,14 @@ it('only shows one toast per problem category across multiple currencies', funct
         'data.fixed_value' => true,
         'data.fixed_values.'.$usd->code => 10,
         'data.fixed_values.'.$gbp->code => 10,
-    ])->call('save')
-        ->assertNotified(__('lunarpanel::discount.notifications.fixed_value_requires_minimum_cart_amount'));
+        'data.min_prices.'.$usd->code => null,
+        'data.min_prices.'.$gbp->code => null,
+    ])->call('save');
 
     $notificationsComponent = new \Filament\Notifications\Livewire\Notifications;
     $notificationsComponent->mount();
 
     expect($notificationsComponent->notifications)->toHaveCount(1);
+    expect($notificationsComponent->notifications->first()->getTitle())
+        ->toBe(__('lunarpanel::discount.notifications.fixed_value_requires_minimum_cart_amount'));
 });

--- a/tests/admin/Feature/Filament/Resources/DiscountResource/Pages/EditDiscountTest.php
+++ b/tests/admin/Feature/Filament/Resources/DiscountResource/Pages/EditDiscountTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
 use function Pest\Laravel\get;
 
 uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
@@ -44,4 +45,107 @@ it('can validate start and end date', function () {
     ])->call('save')->assertHasFormErrors([
         'starts_at' => 'before',
     ]);
+});
+
+it('requires a minimum cart amount for fixed value discounts', function () {
+    $currency = \Lunar\Models\Currency::factory()->create([
+        'code' => 'USD',
+        'default' => true,
+        'enabled' => true,
+    ]);
+
+    $discount = \Lunar\Models\Discount::factory()->create();
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\DiscountResource\Pages\EditDiscount::class,
+        ['record' => $discount->getKey()]
+    )->fillForm([
+        'coupon' => 'FIXED10',
+        'data.fixed_value' => true,
+        'data.fixed_values.'.$currency->code => 10,
+    ])->call('save')
+        ->assertNotified(__('lunarpanel::discount.notifications.fixed_value_requires_minimum_cart_amount'));
+
+    assertDatabaseMissing(\Lunar\Models\Discount::class, [
+        'id' => $discount->id,
+        'coupon' => 'FIXED10',
+    ]);
+});
+
+it('requires the minimum cart amount to be at least the fixed value', function () {
+    $currency = \Lunar\Models\Currency::factory()->create([
+        'code' => 'USD',
+        'default' => true,
+        'enabled' => true,
+    ]);
+
+    $discount = \Lunar\Models\Discount::factory()->create();
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\DiscountResource\Pages\EditDiscount::class,
+        ['record' => $discount->getKey()]
+    )->fillForm([
+        'coupon' => 'FIXED10',
+        'data.fixed_value' => true,
+        'data.fixed_values.'.$currency->code => 10,
+        'data.min_prices.'.$currency->code => 5,
+    ])->call('save')
+        ->assertNotified(__('lunarpanel::discount.notifications.minimum_cart_amount_below_fixed_value'));
+
+    assertDatabaseMissing(\Lunar\Models\Discount::class, [
+        'id' => $discount->id,
+        'coupon' => 'FIXED10',
+    ]);
+});
+
+it('can save a fixed value discount when the minimum cart amount covers the fixed value', function () {
+    $currency = \Lunar\Models\Currency::factory()->create([
+        'code' => 'USD',
+        'default' => true,
+        'enabled' => true,
+    ]);
+
+    $discount = \Lunar\Models\Discount::factory()->create();
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\DiscountResource\Pages\EditDiscount::class,
+        ['record' => $discount->getKey()]
+    )->fillForm([
+        'coupon' => 'FIXED10',
+        'data.fixed_value' => true,
+        'data.fixed_values.'.$currency->code => 10,
+        'data.min_prices.'.$currency->code => 10,
+    ])->call('save')->assertHasNoErrors();
+
+    assertDatabaseHas(\Lunar\Models\Discount::class, [
+        'id' => $discount->id,
+        'coupon' => 'FIXED10',
+    ]);
+});
+
+it('only shows one toast per problem category across multiple currencies', function () {
+    $usd = \Lunar\Models\Currency::factory()->create([
+        'code' => 'USD',
+        'default' => true,
+        'enabled' => true,
+    ]);
+
+    $gbp = \Lunar\Models\Currency::factory()->create([
+        'code' => 'GBP',
+        'enabled' => true,
+    ]);
+
+    $discount = \Lunar\Models\Discount::factory()->create();
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\DiscountResource\Pages\EditDiscount::class,
+        ['record' => $discount->getKey()]
+    )->fillForm([
+        'coupon' => 'FIXED10',
+        'data.fixed_value' => true,
+        'data.fixed_values.'.$usd->code => 10,
+        'data.fixed_values.'.$gbp->code => 10,
+    ])->call('save')
+        ->assertNotified(__('lunarpanel::discount.notifications.fixed_value_requires_minimum_cart_amount'));
+
+    $notificationsComponent = new \Filament\Notifications\Livewire\Notifications;
+    $notificationsComponent->mount();
+
+    expect($notificationsComponent->notifications)->toHaveCount(1);
 });


### PR DESCRIPTION
## Summary
- Fixed value discounts can currently be saved without a minimum cart amount, which can result in a negative cart total when the discount exceeds the cart value.
- Adds validation in `EditDiscount::mutateFormDataBeforeSave()` requiring a minimum cart amount to be set per currency for fixed value discounts, and that it is not lower than the fixed value amount.
- Adds translated notification strings for `en`, `hu`, and `ro`.
- Ensures only one notification per problem category is shown even when multiple currencies are affected.

## Test plan
- [x] `it('requires a minimum cart amount for fixed value discounts')`
- [x] `it('requires the minimum cart amount to be at least the fixed value')`
- [x] `it('can save a fixed value discount when the minimum cart amount covers the fixed value')`
- [x] `it('only shows one toast per problem category across multiple currencies')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)