### PR TITLE
feat: LFP-497 select shipping provider code from configured options

### DIFF
--- a/packages/shipping/src/Providers/Sameday/config.php
+++ b/packages/shipping/src/Providers/Sameday/config.php
@@ -112,4 +112,16 @@ return [
     'home_shipping_id' => env('SAMEDAY_HOME_SHIPPING_ID', 7), // Default service ID for home shipping
 
     'locker_shipping_id' => env('SAMEDAY_LOCKER_SHIPPING_ID', 15), // Default service ID for locker shipping
+
+    /*
+    |--------------------------------------------------------------------------
+    | Locker Support
+    |--------------------------------------------------------------------------
+    |
+    | Whether this provider offers a locker (easybox) delivery variant. Used
+    | to expose a "<provider>-locker" option in the shipping method provider
+    | dropdown, in addition to the base provider option.
+    |
+    */
+    'supports_locker' => true,
 ];

--- a/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Description',
         ],
         'code' => [
-            'label' => 'Code',
+            'label' => 'Provider',
         ],
         'cutoff' => [
             'label' => 'Cutoff',

--- a/packages/table-rate-shipping/resources/lang/es/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/es/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Descripción',
         ],
         'code' => [
-            'label' => 'Código',
+            'label' => 'Proveedor',
         ],
         'cutoff' => [
             'label' => 'Corte',

--- a/packages/table-rate-shipping/resources/lang/fr/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/fr/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Description',
         ],
         'code' => [
-            'label' => 'Code',
+            'label' => 'Fournisseur',
         ],
         'cutoff' => [
             'label' => 'Date limite',

--- a/packages/table-rate-shipping/resources/lang/hu/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/hu/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Leírás',
         ],
         'code' => [
-            'label' => 'Kód',
+            'label' => 'Szolgáltató',
         ],
         'cutoff' => [
             'label' => 'Határidő',

--- a/packages/table-rate-shipping/resources/lang/pl/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/pl/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Opis',
         ],
         'code' => [
-            'label' => 'Kod',
+            'label' => 'Dostawca',
         ],
         'cutoff' => [
             'label' => 'Czas realizacji',

--- a/packages/table-rate-shipping/resources/lang/pt_BR/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/pt_BR/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Descrição',
         ],
         'code' => [
-            'label' => 'Código',
+            'label' => 'Fornecedor',
         ],
         'cutoff' => [
             'label' => 'Horário limite',

--- a/packages/table-rate-shipping/resources/lang/ro/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/ro/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Descriere',
         ],
         'code' => [
-            'label' => 'Cod',
+            'label' => 'Furnizor',
         ],
         'cutoff' => [
             'label' => 'Termen limită',

--- a/packages/table-rate-shipping/resources/lang/tr/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/tr/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Açıklama',
         ],
         'code' => [
-            'label' => 'Kod',
+            'label' => 'Sağlayıcı',
         ],
         'cutoff' => [
             'label' => 'Son Sipariş Saati',

--- a/packages/table-rate-shipping/resources/lang/vi/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/vi/shippingmethod.php
@@ -11,7 +11,7 @@ return [
             'label' => 'Mô tả',
         ],
         'code' => [
-            'label' => 'Mã',
+            'label' => 'Nhà cung cấp',
         ],
         'cutoff' => [
             'label' => 'Thời hạn',

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -11,6 +11,7 @@ use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Lunar\Admin\Support\Resources\BaseResource;
 use Lunar\Shipping\Filament\Resources\ShippingMethodResource\Pages;
 use Lunar\Shipping\Models\Contracts\ShippingMethod;
@@ -101,8 +102,18 @@ class ShippingMethodResource extends BaseResource
 
     public static function getCodeFormComponent(): Component
     {
-        return Forms\Components\TextInput::make('code')
+        return Forms\Components\Select::make('code')
             ->label(__('lunarpanel.shipping::shippingmethod.form.code.label'))
+            ->options(fn () => collect(config('lunar.shipping.providers', []))
+                ->flatMap(function (string $provider) {
+                    $options = [$provider => Str::headline($provider)];
+
+                    if (config("lunar.shipping.{$provider}.supports_locker", false)) {
+                        $options["{$provider}-locker"] = Str::headline("{$provider}-locker");
+                    }
+
+                    return $options;
+                }))
             ->required()
             ->unique(ignoreRecord: true);
     }

--- a/tests/shipping/Unit/Filament/Resources/ShippingMethodResourceTest.php
+++ b/tests/shipping/Unit/Filament/Resources/ShippingMethodResourceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+uses(\Lunar\Tests\Shipping\TestCase::class);
+
+use Lunar\Shipping\Filament\Resources\ShippingMethodResource;
+
+test('code select options are sourced dynamically from the shipping providers config', function () {
+    config(['lunar.shipping.providers' => ['dpd', 'inhouse']]);
+
+    $options = ShippingMethodResource::getCodeFormComponent()->getOptions();
+
+    expect($options)->toBe([
+        'dpd' => 'Dpd',
+        'inhouse' => 'Inhouse',
+    ]);
+});
+
+test('code select adds a headline-labelled locker option for providers that support it', function () {
+    config([
+        'lunar.shipping.providers' => ['sameday'],
+        'lunar.shipping.sameday.supports_locker' => true,
+    ]);
+
+    $options = ShippingMethodResource::getCodeFormComponent()->getOptions();
+
+    expect($options)->toBe([
+        'sameday' => 'Sameday',
+        'sameday-locker' => 'Sameday Locker',
+    ]);
+});
+
+test('code select omits the locker option when supports_locker is missing or false', function () {
+    config([
+        'lunar.shipping.providers' => ['dpd', 'pickup'],
+        'lunar.shipping.pickup.supports_locker' => false,
+    ]);
+
+    $options = ShippingMethodResource::getCodeFormComponent()->getOptions();
+
+    expect($options)->toBe([
+        'dpd' => 'Dpd',
+        'pickup' => 'Pickup',
+    ]);
+});


### PR DESCRIPTION
## Summary
- Replace the free-text \`code\` field on the shipping method Filament resource with a Select sourced from \`lunar.shipping.providers\` config.
- Expose a \`<provider>-locker\` option for providers whose config sets \`supports_locker\` (e.g. Sameday's easybox locker delivery).
- Add \`supports_locker => true\` to the Sameday provider config.
- Rename the "Code" translation label to "Provider" across all locales (en, es, fr, hu, pl, pt_BR, ro, tr, vi).

## Testing
- Added unit tests covering: options sourced dynamically from config, locker option added when supported, locker option omitted when unsupported/missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)