### PR TITLE
fix: LFP-779 keep original image format in media conversions

### DIFF
--- a/packages/core/src/Base/StandardMediaDefinitions.php
+++ b/packages/core/src/Base/StandardMediaDefinitions.php
@@ -18,7 +18,7 @@ class StandardMediaDefinitions implements MediaDefinitionsInterface
             ->border(0, BorderType::Overlay, color: '#FFF')
             ->background('#FFF')
             ->sharpen(10)
-            ->format('webp');
+            ->keepOriginalImageFormat();
     }
 
     public function registerMediaCollections(HasMedia $model): void
@@ -71,7 +71,7 @@ class StandardMediaDefinitions implements MediaDefinitionsInterface
                     )
                     ->border(0, BorderType::Overlay, color: '#FFF')
                     ->background('#FFF')
-                    ->format('webp');
+                    ->keepOriginalImageFormat();
             }
         });
     }

--- a/packages/core/src/Console/Commands/ConvertMediaToWebp.php
+++ b/packages/core/src/Console/Commands/ConvertMediaToWebp.php
@@ -17,6 +17,7 @@ class ConvertMediaToWebp extends Command
     protected $signature = 'lunar:media:convert-webp
         {--ids=* : Only convert the given media IDs}
         {--only-missing : Only regenerate missing conversions after converting the original}
+        {--conversions=* : Only regenerate the given conversions, defaults to every registered conversion}
         {--starting-from-id= : Convert media with an id equal to or higher than the provided value}
         {--chunk=100 : Number of media records to load per chunk when dispatching jobs}';
 
@@ -35,22 +36,13 @@ class ConvertMediaToWebp extends Command
     ];
 
     /**
-     * @var list<string>
-     */
-    protected array $conversions = [
-        'small',
-        'medium',
-        'large',
-        'zoom',
-    ];
-
-    /**
      * Dispatch WebP conversion jobs for media that is not yet WebP.
      */
     public function handle(): int
     {
         $dispatched = 0;
         $onlyMissing = (bool) $this->option('only-missing');
+        $conversions = (array) $this->option('conversions');
         $chunkSize = max(1, (int) $this->option('chunk'));
 
         foreach ($this->modelTypes as $modelClass) {
@@ -60,6 +52,7 @@ class ConvertMediaToWebp extends Command
 
             $query = Media::query()
                 ->where('model_type', $modelType)
+                ->whereHasMorph('model', [$modelClass])
                 ->where(function ($query): void {
                     $query->where('mime_type', '!=', 'image/webp')
                         ->orWhereNull('mime_type');
@@ -74,12 +67,12 @@ class ConvertMediaToWebp extends Command
                 $query->where('id', '>=', $startingFromId);
             }
 
-            $query->chunkById($chunkSize, function ($mediaItems) use (&$dispatched, $onlyMissing): void {
+            $query->chunkById($chunkSize, function ($mediaItems) use (&$dispatched, $onlyMissing, $conversions): void {
                 foreach ($mediaItems as $media) {
                     ConvertMediaToWebpJob::dispatch(
                         $media,
                         $onlyMissing,
-                        $this->conversions,
+                        $conversions,
                     );
 
                     $dispatched++;

--- a/packages/core/src/Jobs/Media/ConvertMediaToWebp.php
+++ b/packages/core/src/Jobs/Media/ConvertMediaToWebp.php
@@ -26,17 +26,17 @@ class ConvertMediaToWebp implements ShouldQueue
     /**
      * The number of times the job may be attempted.
      */
-    protected int $tries = 3;
+    public int $tries = 3;
 
     /**
      * Create a new job instance.
      *
-     * @param  list<string>  $onlyConversions
+     * @param  list<string>  $onlyConversions  Conversions to regenerate, empty regenerates every registered conversion.
      */
     public function __construct(
         public Media $media,
         public bool $onlyMissing = false,
-        public array $onlyConversions = ['small', 'medium', 'large', 'zoom'],
+        public array $onlyConversions = [],
     ) {
         if ($queue = config('media-library.queue_name')) {
             $this->onQueue($queue);

--- a/tests/core/Unit/Console/ConvertMediaToWebpTest.php
+++ b/tests/core/Unit/Console/ConvertMediaToWebpTest.php
@@ -29,8 +29,59 @@ it('dispatches a job per media item', function () {
     Bus::assertDispatched(ConvertMediaToWebpJob::class, function (ConvertMediaToWebpJob $job) use ($media) {
         return $job->media->is($media)
             && $job->onlyMissing === false
-            && $job->onlyConversions === ['small', 'medium', 'large', 'zoom'];
+            && $job->onlyConversions === [];
     });
+});
+
+it('passes the requested conversions to the job', function () {
+    Bus::fake([ConvertMediaToWebpJob::class]);
+
+    $product = Product::factory()->create();
+    $media = $product->addMedia(UploadedFile::fake()->image('avatar.jpg'))
+        ->toMediaCollection(config('lunar.media.collection'));
+
+    $this->artisan(ConvertMediaToWebp::class, [
+        '--ids' => [$media->id],
+        '--conversions' => ['small'],
+    ])->assertSuccessful();
+
+    Bus::assertDispatched(ConvertMediaToWebpJob::class, function (ConvertMediaToWebpJob $job) {
+        return $job->onlyConversions === ['small'];
+    });
+});
+
+it('does not dispatch jobs for media belonging to a soft deleted product', function () {
+    Bus::fake([ConvertMediaToWebpJob::class]);
+
+    $product = Product::factory()->create();
+    $media = $product->addMedia(UploadedFile::fake()->image('avatar.jpg'))
+        ->toMediaCollection(config('lunar.media.collection'));
+
+    $product->delete();
+
+    expect($product->fresh()->trashed())->toBeTrue();
+
+    $this->artisan(ConvertMediaToWebp::class, [
+        '--ids' => [$media->id],
+    ])->assertSuccessful();
+
+    Bus::assertNotDispatched(ConvertMediaToWebpJob::class);
+});
+
+it('does not dispatch jobs for media whose model no longer exists', function () {
+    Bus::fake([ConvertMediaToWebpJob::class]);
+
+    $product = Product::factory()->create();
+    $media = $product->addMedia(UploadedFile::fake()->image('avatar.jpg'))
+        ->toMediaCollection(config('lunar.media.collection'));
+
+    $product->forceDelete();
+
+    $this->artisan(ConvertMediaToWebp::class, [
+        '--ids' => [$media->id],
+    ])->assertSuccessful();
+
+    Bus::assertNotDispatched(ConvertMediaToWebpJob::class);
 });
 
 it('does not dispatch jobs for media already converted to webp', function () {

--- a/tests/core/Unit/Jobs/Media/ConvertMediaToWebpTest.php
+++ b/tests/core/Unit/Jobs/Media/ConvertMediaToWebpTest.php
@@ -3,11 +3,18 @@
 uses(\Lunar\Tests\Core\TestCase::class);
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Lunar\Jobs\Media\ConvertMediaToWebp;
 use Lunar\Models\Product;
 use Spatie\MediaLibrary\Conversions\FileManipulator;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Storage::fake(config('media-library.disk_name'));
+
+    config()->set('media-library.queue_connection_name', 'sync');
+});
 
 it('converts media original and derived conversions to webp', function () {
     $product = Product::factory()->create();
@@ -24,4 +31,42 @@ it('converts media original and derived conversions to webp', function () {
         ->and($media->mime_type)->toBe('image/webp')
         ->and($media->hasGeneratedConversion('small'))->toBeTrue()
         ->and($media->getPath('small'))->toEndWith('.webp');
+});
+
+it('leaves no conversion file behind using the previous extension', function () {
+    $product = Product::factory()->create();
+    $media = $product->addMedia(UploadedFile::fake()->image('photo.png'))
+        ->toMediaCollection(config('lunar.media.collection'));
+
+    $disk = Storage::disk($media->conversions_disk);
+    $conversionDirectory = dirname($media->getPathRelativeToRoot('small'));
+
+    expect($disk->files($conversionDirectory))->toContain("{$conversionDirectory}/photo-small.png");
+
+    (new ConvertMediaToWebp($media))->handle(app(FileManipulator::class));
+
+    $media->refresh();
+
+    expect($disk->files($conversionDirectory))
+        ->not->toContain("{$conversionDirectory}/photo-small.png")
+        ->each->toEndWith('.webp');
+});
+
+it('regenerates every conversion as actual webp data', function () {
+    $product = Product::factory()->create();
+    $media = $product->addMedia(UploadedFile::fake()->image('photo.png'))
+        ->toMediaCollection(config('lunar.media.collection'));
+
+    (new ConvertMediaToWebp($media))->handle(app(FileManipulator::class));
+
+    $media->refresh();
+
+    $disk = Storage::disk($media->conversions_disk);
+
+    foreach (['small', 'medium', 'large', 'zoom'] as $conversion) {
+        $contents = $disk->get($media->getPathRelativeToRoot($conversion));
+
+        expect(substr($contents, 0, 4))->toBe('RIFF')
+            ->and(substr($contents, 8, 4))->toBe('WEBP');
+    }
 });

--- a/tests/core/Unit/Traits/HasMediaTraitTest.php
+++ b/tests/core/Unit/Traits/HasMediaTraitTest.php
@@ -3,11 +3,18 @@
 uses(\Lunar\Tests\Core\TestCase::class);
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
 use Lunar\Base\StandardMediaDefinitions;
 use Lunar\Models\Product;
 use Lunar\Tests\Core\Stubs\TestStandardMediaDefinitions;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Storage::fake(config('media-library.disk_name'));
+
+    config()->set('media-library.queue_connection_name', 'sync');
+});
 
 test('conversions are loaded', function () {
     $definitions = config('lunar.media.definitions');
@@ -28,6 +35,15 @@ test('conversions are loaded', function () {
     expect($image->hasGeneratedConversion('medium'))->toBeTrue();
     expect($image->hasGeneratedConversion('large'))->toBeTrue();
     expect($image->hasGeneratedConversion('zoom'))->toBeTrue();
+});
+
+test('conversions keep the format of the original', function () {
+    $product = Product::factory()->create();
+
+    $product->addMedia(UploadedFile::fake()->image('avatar.webp'))
+        ->toMediaCollection(config('lunar.media.collection'));
+
+    $image = $product->images->first();
 
     expect($image->getPath('small'))->toEndWith('.webp');
     expect($image->getUrl('small'))->toContain('.webp');


### PR DESCRIPTION
## What changed

- `StandardMediaDefinitions` conversions now call `keepOriginalImageFormat()` instead of forcing `format('webp')`, in both the default definition and the per-collection conversions.
- `lunar:media:convert-webp` gains a `--conversions=*` option to regenerate only a subset of conversions. The hard-coded `['small','medium','large','zoom']` list is removed from both the command and the job's constructor default — an empty array now means "every registered conversion".
- The command filters with `whereHasMorph('model', [$modelClass])`, so media owned by soft deleted or missing models is skipped.
- `ConvertMediaToWebp::$tries` changed from `protected` to `public` so the queue worker actually reads it.

## Why

Conversions were hard-coded to emit WebP while the original file kept its uploaded format, so derived files silently diverged from the original. Format migration now belongs solely to the explicit `lunar:media:convert-webp` command. The hard-coded conversion list meant custom conversions were never regenerated, and jobs were being dispatched for media whose owning model no longer existed.

## Testing

Added coverage for:
- conversions keeping the original format (`HasMediaTraitTest`)
- `--conversions` being passed through to the job
- media on soft deleted / force deleted models not dispatching jobs
- no stale conversion file left behind under the previous extension
- every regenerated conversion containing real `RIFF…WEBP` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)