### PR TITLE
fix: LFP-785 include existing cart line quantity in minimum quantity check

### DIFF
--- a/packages/core/src/Exceptions/Carts/MinimumQuantityException.php
+++ b/packages/core/src/Exceptions/Carts/MinimumQuantityException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lunar\Exceptions\Carts;
+
+class MinimumQuantityException extends CartException
+{
+    //
+}

--- a/packages/core/src/Validation/BaseValidator.php
+++ b/packages/core/src/Validation/BaseValidator.php
@@ -29,8 +29,9 @@ abstract class BaseValidator
      *
      * @param  string  $where
      * @param  string  $reason
+     * @param  string  $exception  The CartException class to throw.
      */
-    public function fail($where, $reason): bool
+    public function fail($where, $reason, string $exception = CartException::class): bool
     {
         $messages = new MessageBag(
             is_array($reason) ? $reason : [
@@ -40,7 +41,7 @@ abstract class BaseValidator
 
         throw_if(
             $messages->isNotEmpty(),
-            CartException::class,
+            $exception,
             $messages
         );
 

--- a/packages/core/src/Validation/CartLine/CartLineQuantity.php
+++ b/packages/core/src/Validation/CartLine/CartLineQuantity.php
@@ -2,6 +2,10 @@
 
 namespace Lunar\Validation\CartLine;
 
+use Lunar\Base\Purchasable;
+use Lunar\Exceptions\Carts\MinimumQuantityException;
+use Lunar\Facades\CartSession;
+use Lunar\Models\CartLine;
 use Lunar\Validation\BaseValidator;
 
 class CartLineQuantity extends BaseValidator
@@ -40,13 +44,22 @@ class CartLineQuantity extends BaseValidator
             );
         }
 
-        if ($purchasable && $quantity < $purchasable->min_quantity) {
-            $this->fail(
-                'cart',
-                __('lunar::exceptions.minimum_quantity', [
-                    'quantity' => $purchasable->min_quantity,
-                ])
-            );
+        if ($purchasable) {
+            $minCheckQuantity = $quantity;
+
+            if (! $cartLineId && $currentLine = $this->getCurrentCartLine($purchasable)) {
+                $minCheckQuantity += $currentLine->quantity;
+            }
+
+            if ($minCheckQuantity < $purchasable->min_quantity) {
+                $this->fail(
+                    'cart',
+                    __('lunar::exceptions.minimum_quantity', [
+                        'quantity' => $purchasable->min_quantity,
+                    ]),
+                    MinimumQuantityException::class
+                );
+            }
         }
 
         if ($purchasable && ($quantity % ($purchasable->quantity_increment ?? 1)) !== 0) {
@@ -60,5 +73,14 @@ class CartLineQuantity extends BaseValidator
         }
 
         return $this->pass();
+    }
+
+    /**
+     * Get the current cart line for the given purchasable.
+     */
+    protected function getCurrentCartLine(Purchasable $purchasable): ?CartLine
+    {
+        return CartSession::current()?->lines
+            ?->first(fn ($line) => $line->purchasable->is($purchasable));
     }
 }

--- a/tests/core/Unit/Validation/CartLine/CartLineQuantityTest.php
+++ b/tests/core/Unit/Validation/CartLine/CartLineQuantityTest.php
@@ -3,7 +3,9 @@
 uses(\Lunar\Tests\Core\TestCase::class)
     ->group('validation.cart_line');
 
+use Illuminate\Support\Facades\Session;
 use Lunar\Exceptions\Carts\CartException;
+use Lunar\Exceptions\Carts\MinimumQuantityException;
 use Lunar\Models\Cart;
 use Lunar\Models\Currency;
 use Lunar\Validation\CartLine\CartLineQuantity;
@@ -73,7 +75,115 @@ test('can validate minimum quantity', function () {
     );
 
     expect(fn () => $validator->validate())
-        ->toThrow(CartException::class, __('lunar::exceptions.minimum_quantity', ['quantity' => $purchasable->min_quantity]));
+        ->toThrow(MinimumQuantityException::class, __('lunar::exceptions.minimum_quantity', ['quantity' => $purchasable->min_quantity]));
+});
+
+test('can validate minimum quantity when combined with the quantity already in the cart', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = \Lunar\Models\ProductVariant::factory()->create([
+        'min_quantity' => 5,
+    ]);
+
+    $purchasable->prices()->create(
+        \Lunar\Models\Price::factory()->make(['currency_id' => $currency->id])->getAttributes()
+    );
+
+    $cart->lines()->create([
+        'purchasable_type' => \Lunar\Models\ProductVariant::class,
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 3,
+    ]);
+
+    Session::put(config('lunar.cart_session.session_key'), $cart->id);
+
+    $validator = (new CartLineQuantity)->using(
+        cart: $cart,
+        purchasable: $purchasable,
+        quantity: 2,
+        meta: []
+    );
+
+    expect($validator->validate())->toBeTrue();
+});
+
+test('can validate minimum quantity fails when combined with the quantity already in the cart is still below the minimum', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = \Lunar\Models\ProductVariant::factory()->create([
+        'min_quantity' => 5,
+    ]);
+
+    $purchasable->prices()->create(
+        \Lunar\Models\Price::factory()->make(['currency_id' => $currency->id])->getAttributes()
+    );
+
+    $cart->lines()->create([
+        'purchasable_type' => \Lunar\Models\ProductVariant::class,
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    Session::put(config('lunar.cart_session.session_key'), $cart->id);
+
+    $validator = (new CartLineQuantity)->using(
+        cart: $cart,
+        purchasable: $purchasable,
+        quantity: 2,
+        meta: []
+    );
+
+    expect(fn () => $validator->validate())
+        ->toThrow(MinimumQuantityException::class, __('lunar::exceptions.minimum_quantity', ['quantity' => 5]));
+});
+
+test('does not double count the cart line quantity against itself when validating via cart line id', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = \Lunar\Models\ProductVariant::factory()->create([
+        'min_quantity' => 5,
+    ]);
+
+    $line = $cart->lines()->create([
+        'purchasable_type' => \Lunar\Models\ProductVariant::class,
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 10,
+    ]);
+
+    Session::put(config('lunar.cart_session.session_key'), $cart->id);
+
+    $validator = (new CartLineQuantity)->using(
+        cart: $cart,
+        purchasable: null,
+        cartLineId: $line->id,
+        quantity: 5,
+        meta: []
+    );
+
+    expect($validator->validate())->toBeTrue();
+
+    $validator = (new CartLineQuantity)->using(
+        cart: $cart,
+        purchasable: null,
+        cartLineId: $line->id,
+        quantity: 4,
+        meta: []
+    );
+
+    expect(fn () => $validator->validate())
+        ->toThrow(MinimumQuantityException::class, __('lunar::exceptions.minimum_quantity', ['quantity' => 5]));
 });
 
 test('can validate quantity increment quantity', function (array $quantities, int $increment) {


### PR DESCRIPTION
## Summary
- Cart line quantity validation could allow a purchasable's total quantity in the cart to drop below its `min_quantity` when an existing line for the same purchasable already accounted for part of the minimum.
- `CartLineQuantity` now sums the incoming quantity with any existing cart line quantity for the same purchasable before comparing against `min_quantity`.
- Added a dedicated `MinimumQuantityException` (extends `CartException`) so callers can distinguish a minimum-quantity failure from other cart validation errors. `BaseValidator::fail()` now accepts an optional exception class to throw.

## Testing
- Added unit tests covering: combined quantity meeting the minimum, combined quantity still below the minimum, and updating an existing cart line by `cartLineId` (ensuring it isn't double-counted against itself).