### PR TITLE
fix: LFP-795 exclude cart lines with different meta from min quantity check

### DIFF
--- a/packages/core/src/Validation/CartLine/CartLineQuantity.php
+++ b/packages/core/src/Validation/CartLine/CartLineQuantity.php
@@ -87,6 +87,7 @@ class CartLineQuantity extends BaseValidator
             return null;
         }
 
+        // If new keys are ever stored in meta, check whether they should affect this cart line match.
         $currentLine = app(
             config('lunar.cart.actions.get_existing_cart_line', GetExistingCartLine::class)
         )->execute(

--- a/packages/core/src/Validation/CartLine/CartLineQuantity.php
+++ b/packages/core/src/Validation/CartLine/CartLineQuantity.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Validation\CartLine;
 
+use Lunar\Actions\Carts\GetExistingCartLine;
 use Lunar\Base\Purchasable;
 use Lunar\Exceptions\Carts\MinimumQuantityException;
 use Lunar\Facades\CartSession;
@@ -80,7 +81,20 @@ class CartLineQuantity extends BaseValidator
      */
     protected function getCurrentCartLine(Purchasable $purchasable): ?CartLine
     {
-        return CartSession::current()?->lines
-            ?->first(fn ($line) => $line->purchasable->is($purchasable));
+        $cart = $this->parameters['cart'] ?? CartSession::current();
+
+        if (! $cart) {
+            return null;
+        }
+
+        $currentLine = app(
+            config('lunar.cart.actions.get_existing_cart_line', GetExistingCartLine::class)
+        )->execute(
+            cart: $cart,
+            purchasable: $purchasable,
+            meta: (array) ($this->parameters['meta'] ?? [])
+        );
+
+        return $currentLine instanceof CartLine ? $currentLine : null;
     }
 }

--- a/tests/core/Unit/Validation/CartLine/CartLineQuantityTest.php
+++ b/tests/core/Unit/Validation/CartLine/CartLineQuantityTest.php
@@ -94,9 +94,10 @@ test('can validate minimum quantity when combined with the quantity already in t
     );
 
     $cart->lines()->create([
-        'purchasable_type' => \Lunar\Models\ProductVariant::class,
+        'purchasable_type' => $purchasable->getMorphClass(),
         'purchasable_id' => $purchasable->id,
         'quantity' => 3,
+        'meta' => ['personalization' => 'asd'],
     ]);
 
     Session::put(config('lunar.cart_session.session_key'), $cart->id);
@@ -105,10 +106,45 @@ test('can validate minimum quantity when combined with the quantity already in t
         cart: $cart,
         purchasable: $purchasable,
         quantity: 2,
-        meta: []
+        meta: ['personalization' => 'asd']
     );
 
     expect($validator->validate())->toBeTrue();
+});
+
+test('minimum quantity excludes cart lines with different meta', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = \Lunar\Models\ProductVariant::factory()->create([
+        'min_quantity' => 5,
+    ]);
+
+    $purchasable->prices()->create(
+        \Lunar\Models\Price::factory()->make(['currency_id' => $currency->id])->getAttributes()
+    );
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 5,
+        'meta' => ['personalization' => 'asd'],
+    ]);
+
+    Session::put(config('lunar.cart_session.session_key'), $cart->id);
+
+    $validator = (new CartLineQuantity)->using(
+        cart: $cart,
+        purchasable: $purchasable,
+        quantity: 1,
+        meta: ['personalization' => 'asddddd']
+    );
+
+    expect(fn () => $validator->validate())
+        ->toThrow(MinimumQuantityException::class, __('lunar::exceptions.minimum_quantity', ['quantity' => 5]));
 });
 
 test('can validate minimum quantity fails when combined with the quantity already in the cart is still below the minimum', function () {


### PR DESCRIPTION
## What changed
`CartLineQuantity::getCurrentCartLine()` now resolves the matching cart line via the `GetExistingCartLine` action (matching on both `purchasable` and `meta`), instead of matching any cart line with the same purchasable.

## Why
Cart lines for the same purchasable but with different `meta` (e.g. personalization) were being combined when checking the minimum quantity, incorrectly aggregating their quantities together.

## Testing
- Added a unit test asserting that a cart line with different `meta` is excluded from the minimum quantity check.
- Updated existing test to assert matching `meta` lines are still combined as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)